### PR TITLE
Don't panic in SetLayout

### DIFF
--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -371,7 +371,6 @@ func (wrk *Workspace) SetLayout(name string) {
 	default:
 		panic(fmt.Sprintf("Unknown layout state '%d'.", state))
 	}
-	panic("unreachable")
 }
 
 func (wrk *Workspace) findLayout(name string) (state int, index int) {


### PR DESCRIPTION
The `panic()` at the end of `SetLayout` causes the function to panic **every time**, so I removed it.
