### PR TITLE
FFM Raise Workspace switch bug fix

### DIFF
--- a/wm/state.go
+++ b/wm/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/BurntSushi/xgbutil/ewmh"
 	"github.com/BurntSushi/xgbutil/xevent"
 	"github.com/BurntSushi/xgbutil/xwindow"
+	"github.com/BurntSushi/xgbutil/mousebind"
 
 	"github.com/BurntSushi/wingo/focus"
 	"github.com/BurntSushi/wingo/heads"
@@ -154,6 +155,7 @@ func Workspace() *workspace.Workspace {
 }
 
 func SetWorkspace(wrk *workspace.Workspace, greedy bool) {
+	mousebind.GrabPointer(X,Root.Id,Root.Id,0)
 	old := Workspace()
 	wrk.Activate(greedy)
 	if old != Workspace() {
@@ -163,6 +165,7 @@ func SetWorkspace(wrk *workspace.Workspace, greedy bool) {
 	ewmhVisibleDesktops()
 	ewmhCurrentDesktop()
 	Heads.EwmhWorkarea()
+	mousebind.UngrabPointer(X)
 }
 
 func AddWorkspace(name string) error {


### PR DESCRIPTION
With FFM and FFM Raise enabled, switching to a workspace that places two overlapping windows under the cursor would result in the windows being rapidly raised and focused alternately.

My fix is a bit of a hack and probably hides an underlying issue, but it solves the issue for now.

All it does is grab the pointer at the beginning of the wm.SetWorkspace function and releases it when done.
