### PR TITLE
Corrects workspace geometries on ApplyStruts

### DIFF
--- a/heads/heads.go
+++ b/heads/heads.go
@@ -165,7 +165,7 @@ func (hds *Heads) Reload(clients Clients) {
 
 func (hds *Heads) ApplyStruts(clients Clients) {
 	hds.workarea = make(xinerama.Heads, len(hds.geom))
-	for i, hd := range hds.geom {
+	for i, hd := range query(hds.X) {
 		hds.workarea[i] = xrect.New(hd.X(), hd.Y(), hd.Width(), hd.Height())
 	}
 


### PR DESCRIPTION
Fixes incorrect workspace geometries when Reload'ing.
This fixes a problem with incorrect window handling after changing the resolution or display layout.
One easy way to reproduce this was to change the resolution, then maximize a window (Mod4-x). This would result in the window being resized to the old, now changed size.
