### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/focus/focus.go
+++ b/focus/focus.go
@@ -30,7 +30,7 @@ func Initialize(xu *xgbutil.XUtil) {
 	clientSet = make(map[xproto.Window]bool, 100)
 }
 
-// Returns the currently focused client, or nil if no client has focus.
+// Current returns the currently focused client, or nil if no client has focus.
 func Current() Client {
 	if len(Clients) == 0 {
 		return nil

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -58,7 +58,7 @@ type hook struct {
 	consequences []string
 }
 
-// Initializes the hooks package with a Gribble execution environment and
+// Initialize: Initializes the hooks package with a Gribble execution environment and
 // a file path to a wini formatted hooks configuration file. If the
 // initialization fails, only a warning is logged since hooks are not
 // essential for Wingo to run.

--- a/layout/maximized.go
+++ b/layout/maximized.go
@@ -84,11 +84,11 @@ func (m *Maximized) Prev() {
 	}
 }
 
-// This is useful, but can be implemented later
+// SwitchNext is useful, but can be implemented later
 func (m *Maximized) SwitchNext() {
 }
 
-// This is useful, but can be implemented later
+// SwitchPrev is useful, but can be implemented later
 func (m *Maximized) SwitchPrev() {
 }
 

--- a/misc/misc.go
+++ b/misc/misc.go
@@ -21,7 +21,7 @@ func Min(a, b int) int {
 	return b
 }
 
-// This exists because '%' isn't really modulus; it's *remainder*.
+// Mod: This exists because '%' isn't really modulus; it's *remainder*.
 // e.g., (-1) % 2 = -1 but (-1) mod 2 = 1.
 func Mod(x, m int) int {
 	r := x % m
@@ -39,7 +39,7 @@ func Round(n float64) int {
 	return int(ceil) - 1
 }
 
-// Prints a simple stack trace without panicing.
+// StackTrace: Prints a simple stack trace without panicing.
 //
 // XXX: I tried using runtime.Stack, but I couldn't get it to work...
 func StackTrace() string {

--- a/prompt/cycle.go
+++ b/prompt/cycle.go
@@ -336,7 +336,7 @@ func (cycle *Cycle) Prev() {
 	cycle.highlight()
 }
 
-// AddItem should be thought of as a *CycleItem constructor. Its main role is
+// AddChoice: should be thought of as a *CycleItem constructor. Its main role is
 // to adapt a CycleChoice value to a value that is suitable for the cycle
 // prompt to paint onto its window. The resulting CycleItem value can be used
 // to update the image/text.

--- a/xclient/frame.go
+++ b/xclient/frame.go
@@ -49,7 +49,7 @@ func (c *Client) Frame() frame.Frame {
 	return c.frame
 }
 
-// Geom returns the geometry of the client window (not the frame window).
+// ClientGeom: Geom returns the geometry of the client window (not the frame window).
 func (c *Client) ClientGeom() xrect.Rect {
 	return c.win.Geom
 }

--- a/xclient/state.go
+++ b/xclient/state.go
@@ -36,7 +36,7 @@ func (c *Client) HasState(name string) bool {
 	return ok
 }
 
-// Don't save when moving or resizing.
+// SaveState: Don't save when moving or resizing.
 // Also don't save when client's workspace isn't visible.
 func (c *Client) SaveState(name string) {
 	if c.workspace == nil {
@@ -54,7 +54,7 @@ func (c *Client) CopyState(src, dest string) {
 	}
 }
 
-// Don't revert to regular geometry when moving/resizing. We can still revert
+// LoadState: Don't revert to regular geometry when moving/resizing. We can still revert
 // the frame or the maximized state, though.
 // Also don't load *ever* when client's workspace isn't visible.
 func (c *Client) LoadState(name string) {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say **`opt out`** to opt out of future CodeLingo outreach PRs.*