### PR TITLE
docs: use `go install` to install wingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ mostly ICCCM and EWMH compliant (see COMPLIANCE).
 If you have Go installed and configured on your machine, all you need to do is:
 (For Archlinux users, Wingo is in the AUR.)
 
-    go get github.com/BurntSushi/wingo
+    go install github.com/BurntSushi/wingo@latest
 
 And in your $HOME/.xinitrc:
 


### PR DESCRIPTION
Nowadays, `go get` way is deprecated to build and install pkgs.

See: https://go.dev/doc/go-get-install-deprecation